### PR TITLE
Added libgbm-devel cdt

### DIFF
--- a/mesa-libgbm-devel-cos6-x86_64/build.sh
+++ b/mesa-libgbm-devel-cos6-x86_64/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot
+mkdir -p ${PREFIX}/x86_64-conda-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd ${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .
+popd
+pushd ${PREFIX}/x86_64-conda-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .
+popd
+

--- a/mesa-libgbm-devel-cos6-x86_64/meta.yaml
+++ b/mesa-libgbm-devel-cos6-x86_64/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: mesa-libgbm-cos6-x86_64
+  name: mesa-libgbm-devel-cos6-x86_64
   version: 11.0.7
 
 source:

--- a/mesa-libgbm-devel-cos6-x86_64/meta.yaml
+++ b/mesa-libgbm-devel-cos6-x86_64/meta.yaml
@@ -1,0 +1,33 @@
+package:
+  name: mesa-libgbm-cos6-x86_64
+  version: 11.0.7
+
+source:
+  - url: http://vault.centos.org/centos/6.10/os/x86_64/Packages/mesa-libgbm-devel-11.0.7-4.el6.x86_64.rpm
+    sha256: 8bea09887822544f4a300fe88c09d5153c8e80dbb154ab69773e703c8cd06508
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/6.10/os/Source/SPackages/mesa-11.0.7-4.el6.src.rpm
+    folder: source
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+  build:
+    - mesa-libgbm-cos6-x86_64 ==11.0.7
+  host:
+    - mesa-libgbm-cos6-x86_64 ==11.0.7
+  run:
+    - mesa-libgbm-cos6-x86_64 ==11.0.7
+
+about:
+  home: http://www.mesa3d.org
+  license: MIT
+  license_family: MIT
+  summary: "(CDT) Mesa gbm development package"
+  description: |
+        Mesa gbm runtime development package.


### PR DESCRIPTION
- Relevant dependency PRs:
  - AnacondaRecipes/qtwebengine-feedstock#1

### Explanation of changes:

- Added cdt for `libgbm-devel` to accompany existing `libgbm` cdt.
